### PR TITLE
Reduce enum noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog] and this project adheres to [Semantic Versioning]
 
+## 2.0.0-rc3 - 2019-10-05
+
+#### Changed
+
+- Changed the return value of the `toString` method from an arbitrary string with the enum class name and 
+the enum value to simply returning the enum value. In the example `YourNamespace\\Enums\\Compass@North` would 
+now simply return 'North'.
+- Instead of having each enum generate its own set of boilerplate much of the generically shared code has 
+been moved to a trait to facilitate building your own enums without the code generator and making enums 
+generally less "noisy".
+
 ## 2.0.0-rc2 - 2019-09-28
 
 #### Fixed

--- a/resources/templates/enum.php
+++ b/resources/templates/enum.php
@@ -6,38 +6,22 @@
 namespace <?= $this->getNamespace() ?>;
 
 use Cspray\Yape\Enum;
+use Cspray\Yape\EnumTrait;
 use Cspray\Yape\Exception\InvalidArgumentException;
 
 final class <?= $this->getEnumName() ?> implements Enum {
 
+    use EnumTrait;
+
+    private $enumValue;
+
+    private function __construct(string $enumValue) {
+        $this->enumValue = $enumValue;
+    }
+
     // It is imperative that if you add a new value post code generation you add the method name here!
-    private const POSSIBLE_VALUES = [<?php foreach($this->getEnumValues() as $enumValue): echo var_export($enumValue, true), ', '; endforeach; ?>];
-
-    private static $container = [];
-
-    private $enumConstName;
-
-    private function __construct(string $enumConstName) {
-        $this->enumConstName = $enumConstName;
-    }
-
-    /**
-    * Return a collection of all the possible values that this enum could have.
-    *
-    * @return <?= $this->getEnumName() ?>[]
-    */
-    public static function values() : array {
-        self::primeContainer();
-        return array_values(self::$container);
-    }
-
-    public static function valueOf(string $name) : self {
-        self::primeContainer();
-        if (!isset(self::$container[$name])) {
-            $msg = sprintf('The value "%s" is not a valid %s name', $name, self::class);
-            throw new InvalidArgumentException($msg);
-        }
-        return self::$container[$name];
+    static protected function getAllowedValues() : array {
+        return [<?php foreach($this->getEnumValues() as $enumValue): echo var_export($enumValue, true), ', '; endforeach; ?>];
     }
 
     <?php foreach($this->getEnumValues() as $enumValue): ?>
@@ -46,28 +30,8 @@ final class <?= $this->getEnumName() ?> implements Enum {
     }
 
     <?php endforeach; ?>
-    static private function getSingleton(string $name) {
-        if (!isset(self::$container[$name])) {
-            self::$container[$name] = new self($name);
-        }
-
-        return self::$container[$name];
-    }
-
-    static private function primeContainer() {
-        if (count(self::$container) !== count(self::POSSIBLE_VALUES)) {
-            foreach (self::POSSIBLE_VALUES as $enumValue) {
-                self::$enumValue();
-            }
-        }
-    }
-
-    public function equals($<?= lcfirst($this->getEnumName()) ?>) : bool {
-        return $this === $<?= lcfirst($this->getEnumName()) ?>;
-    }
 
     public function toString() : string {
-        return get_class($this) . '@' . $this->enumConstName;
+        return $this->enumValue;
     }
-
 }

--- a/src/EnumTrait.php
+++ b/src/EnumTrait.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace Cspray\Yape;
+
+use Cspray\Yape\Exception\InvalidArgumentException;
+
+/**
+ *
+ * @package Cspray\Yape
+ * @license See LICENSE in source root
+ */
+trait EnumTrait {
+
+    static private $container;
+
+    static public function values() : array {
+        self::primeContainer();
+        return array_values(self::$container);
+    }
+
+    static public function valueOf(string $name) {
+        self::primeContainer();
+        if (!isset(self::$container[$name])) {
+            $msg = sprintf('The value "%s" is not a valid %s name', $name, self::class);
+            throw new InvalidArgumentException($msg);
+        }
+        return self::$container[$name];
+    }
+
+    public function equals($compare) : bool {
+        return $this === $compare;
+    }
+
+    static protected function getSingleton(...$constructorArgs) : self {
+        $name = $constructorArgs[0];
+        if (!isset(self::$container[$name])) {
+            self::$container[$name] = new self(...$constructorArgs);
+        }
+
+        return self::$container[$name];
+    }
+
+    static private function primeContainer() {
+        $allowedValues = self::getAllowedValues();
+        if (count(self::$container) !== count($allowedValues)) {
+            foreach ($allowedValues as $enumValue) {
+                self::$enumValue();
+            }
+        }
+    }
+
+    static abstract protected function getAllowedValues() : array;
+
+}

--- a/test/EnumTest.php
+++ b/test/EnumTest.php
@@ -120,7 +120,7 @@ abstract class EnumTest extends TestCase {
         $data = [];
         $enumDefinition = $this->getEnumDefinition();
         foreach ($enumDefinition->getEnumValues() as $enumValue) {
-            $data[] = [$enumValue, $enumDefinition->getNamespace() . '\\' . $enumDefinition->getEnumName() . '@' . $enumValue];
+            $data[] = [$enumValue, $enumValue];
         }
 
         return $data;


### PR DESCRIPTION
- The enum implementation that was generated shares a lot of boilerplate
among other enums and generally results in an implementation that has a
lot of noise around it compared to what we want to achieve. To reduce
the visual clutter in generated enums much of the functionality was
moved out into an EnumTrait.

- Instead of returning an arbitrary toString() we are now simply
returning the string representation (i.e. method name used to
instantiate your enum instance) of the enum that was generated. This is
more inline with our Java inspiration and is also more intuitive to use
in places where you might want to show or use the string representation.